### PR TITLE
Glib installation instructions

### DIFF
--- a/exercises/ex08/ex08.md
+++ b/exercises/ex08/ex08.md
@@ -24,12 +24,24 @@ to another library, or just using core C features?
 
 *  What do you have to do to compile and run a "Hello GLib" example?
 
-2) Install Glib (detail to follow)
+2) Install Glib
+
+In many cases, Glib will already be installed, but in the case that it
+is not, you can download the package
+[here](https://www.gtk.org/download/linux.php). The tarball should
+include a file called `INSTALL.in` that includes instructions for
+installing Glib.
+
+If the `configure` script has missing dependencies, go ahead and
+install them.
+
 
 3) Read [this Glib
 tutorial](http://www.ibm.com/developerworks/linux/tutorials/l-glib/)
 Their first example, `ex_compile.c`, is in this directory.
 Following their instructions, compile it on the command line and run it.
+If you are using pkg-config to compile, note that the single quotes
+that the tutorial uses should actually be the \` character.
 
 4) Write a `Makefile` that compiles `ex_compile.c` cleanly.
 


### PR DESCRIPTION
Two things happened with debugging during office hours that I did not (yet?) address in this:

1) Both students were missing the `libmount` dependency. Online, I found that you could get around this by using the flag `--enable-libmount=no`; however, I'm not sure what `libmount` does, thus I don't know if this is the correct solution. 

2) After installing Glib, neither of the commands listed on the tutorial page worked for them. We found a command on a [stack overflow](https://stackoverflow.com/questions/17360635/glibconfig-h-no-such-file-or-directory) that worked; however, I don't know enough about `pkg-config` to know why the original command didn't work.

```
gcc `pkg-config --cflags glib-2.0` ex_compile.c `pkg-config --libs glib-2.0`
```

Should the above two points be included in this markdown?